### PR TITLE
Replace github output

### DIFF
--- a/.github/workflows/greet_dispatch.yml
+++ b/.github/workflows/greet_dispatch.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Set the value
         id: set_name
-        run: echo "::set-output name=msg::Hello ${{ github.event.inputs.name }}!\\n- in ${{ github.event.inputs.email }}!\\n- in ${{ github.event.inputs.location }}!"
+        run: echo "msg=Hello ${{ github.event.inputs.name }}!\\n- in ${{ github.event.inputs.email }}!\\n- in ${{ github.event.inputs.location }}!" >> $GITHUB_OUTPUT
       - name: Use the value
         run: echo "${{ steps.set_name.outputs.msg }}"
       - name: Send to slack channel


### PR DESCRIPTION
FYI: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/